### PR TITLE
feat: nginx demo app — NFS volume + Postgres on dedicated iSCSI/LVM disk

### DIFF
--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -41,6 +41,7 @@
         homelable_backup_healthcheck_url: "{{ terraform_outputs.uptime_backup_homelable_url.value | default('') }}"
         gramps_backup_healthcheck_url: "{{ terraform_outputs.uptime_backup_gramps_url.value | default('') }}"
         dawarich_backup_healthcheck_url: "{{ terraform_outputs.uptime_backup_dawarich_url.value | default('') }}"
+        nginx_demo_backup_healthcheck_url: "{{ terraform_outputs.uptime_backup_nginx_demo_url.value | default('') }}"
       vars:
         terraform_outputs: "{{ (terraform_state_raw.contents | from_json).outputs | default({}) }}"
 
@@ -86,3 +87,5 @@
       tags: gramps,app
     - role: dawarich
       tags: dawarich,app
+    - role: nginx_demo
+      tags: nginx_demo,app

--- a/ansible/host_vars/backups/variables.yaml
+++ b/ansible/host_vars/backups/variables.yaml
@@ -17,3 +17,4 @@ backup_folders:
   - "homelable"
   - "gramps"
   - "dawarich"
+  - "nginx_demo"

--- a/ansible/host_vars/docker/variables.yaml
+++ b/ansible/host_vars/docker/variables.yaml
@@ -59,3 +59,7 @@ gramps_backup_encryption_passphrase: "{{ backup_passphrase }}"
 dawarich_backup_enabled: true
 dawarich_backup_borgmatic_target: "ssh://{{ backup_storage_box_username }}@{{ backup_storage_box_hostname }}/{{ backup_storage_box_path }}/dawarich"
 dawarich_backup_encryption_passphrase: "{{ backup_passphrase }}"
+
+nginx_demo_backup_enabled: true
+nginx_demo_backup_borgmatic_target: "ssh://{{ backup_storage_box_username }}@{{ backup_storage_box_hostname }}/{{ backup_storage_box_path }}/nginx_demo"
+nginx_demo_backup_encryption_passphrase: "{{ backup_passphrase }}"

--- a/ansible/roles/docker_service/tasks/main.yaml
+++ b/ansible/roles/docker_service/tasks/main.yaml
@@ -1,4 +1,12 @@
 ---
+# Requis par le driver de volume "local" de Docker quand des options NFS
+# (type: "nfs") sont utilisées — dockerd délègue le montage à mount.nfs.
+- name: Install nfs-common for NFS-backed Docker volumes
+  become: true
+  ansible.builtin.apt:
+    name: nfs-common
+    state: present
+
 - name: Ensure docker service app folder exists
   become: true
   loop:

--- a/ansible/roles/nginx_demo/defaults/main.yml
+++ b/ansible/roles/nginx_demo/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+nginx_demo_base_path: "{{ docker_base_path }}/nginx_demo"
+nginx_demo_domain: nginx.sylvain.cloud
+
+# BDD postgres — démo/validation du chemin de stockage bloc (iSCSI + LVM,
+# LUN "demo_test" attaché en scsi0 par Tofu, voir tofu/proxmox). N'est pas
+# consommée par nginx, sert uniquement à valider le mécanisme de LUN dédié.
+nginx_demo_db_name: nginx_demo_db
+nginx_demo_db_user: nginx_demo
+nginx_demo_db_password: "{{ (backup_passphrase ~ '-nginx-demo-db') | hash('sha256') }}"
+
+# Disque scsi0 = premier (et seul, pour l'instant) disque du storage
+# "iscsi-lvm" attaché à la VM (voir docker_vm_data_disks.demo_test dans
+# tofu/proxmox). /dev/sda n'est utilisé QUE pour le tout premier mkfs — dès
+# que le filesystem existe, il est retrouvé et monté par UUID (fixé ici, via
+# `mkfs -U` à la création), donc plus jamais par chemin /dev/sdX. C'est ce qui
+# rend ce montage stable même après ajout d'un second disque iSCSI/LVM qui
+# décalerait la numérotation scsi/sdX à un reboot ultérieur.
+nginx_demo_data_device: /dev/sda
+nginx_demo_data_uuid: 8bb22809-3c57-45c5-82dc-a15837cdc52e
+nginx_demo_data_mount: "{{ nginx_demo_base_path }}/postgresql"
+
+# Volume fichier — export NFS du NAS, sous-dossier dédié à cette appli.
+nginx_demo_nas_ip: 192.168.1.137
+nginx_demo_nfs_export: /volume1/apps/nginx_demo
+
+# Borgmatic backup configuration
+nginx_demo_backup_enabled: true
+nginx_demo_backup_borgmatic_target: ""
+nginx_demo_backup_encryption_passphrase: ""
+nginx_demo_backup_healthcheck_url: ""

--- a/ansible/roles/nginx_demo/handlers/main.yml
+++ b/ansible/roles/nginx_demo/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart nginx_demo
+  ansible.builtin.systemd:
+    name: dc@nginx_demo
+    scope: user
+    state: restarted

--- a/ansible/roles/nginx_demo/tasks/main.yml
+++ b/ansible/roles/nginx_demo/tasks/main.yml
@@ -1,0 +1,102 @@
+---
+- name: Ensure Nginx Demo app folder exists
+  ansible.builtin.file:
+    mode: "0755"
+    path: "{{ nginx_demo_base_path }}"
+    state: directory
+    owner: "{{ ansible_facts['user_id'] }}"
+    group: "{{ ansible_facts['user_gid'] }}"
+
+# Cherche le filesystem par UUID fixe plutôt que par chemin /dev/sdX : ce
+# dernier peut se décaler entre deux boots dès qu'un second disque iSCSI/LVM
+# est attaché à la VM. rc == 0 => le filesystem existe déjà quelque part
+# (peu importe sur quel /dev/sdX il est aujourd'hui) => on ne reformate pas.
+- name: Check whether the demo_test filesystem already exists (by UUID)
+  ansible.builtin.command: "blkid -U {{ nginx_demo_data_uuid }}"
+  register: nginx_demo_uuid_lookup
+  changed_when: false
+  failed_when: false
+
+# Disque scsi0, attaché par Tofu (docker_vm_data_disks.demo_test) sur le
+# storage Proxmox "iscsi-lvm". Ne tourne qu'au tout premier run (cf. tâche
+# précédente) — /dev/sda n'est fiable que pour ce mkfs initial, sur une VM où
+# c'est encore le seul disque iSCSI/LVM attaché. Le filesystem est créé avec
+# un UUID fixé (nginx_demo_data_uuid) pour ne plus jamais dépendre du chemin
+# ensuite.
+- name: Create ext4 filesystem on the demo_test iSCSI/LVM disk (first run only)
+  become: true
+  when: nginx_demo_uuid_lookup.rc != 0
+  community.general.filesystem:
+    fstype: ext4
+    dev: "{{ nginx_demo_data_device }}"
+    opts: "-U {{ nginx_demo_data_uuid }}"
+
+- name: Create Postgres data mount point
+  ansible.builtin.file:
+    path: "{{ nginx_demo_data_mount }}"
+    state: directory
+    mode: "0750"
+    owner: "{{ ansible_facts['user_id'] }}"
+    group: "{{ ansible_facts['user_gid'] }}"
+
+- name: Mount the demo_test disk by UUID and persist in fstab
+  become: true
+  ansible.posix.mount:
+    path: "{{ nginx_demo_data_mount }}"
+    src: "UUID={{ nginx_demo_data_uuid }}"
+    fstype: ext4
+    opts: defaults,nofail
+    state: mounted
+
+- name: Template compose configuration
+  notify: Restart nginx_demo
+  ansible.builtin.template:
+    src: "templates/compose.yaml"
+    dest: "{{ nginx_demo_base_path }}/compose.yaml"
+    owner: "{{ ansible_facts['user_id'] }}"
+    group: "{{ ansible_facts['user_gid'] }}"
+    mode: "0644"
+
+- name: Template environment configuration
+  notify: Restart nginx_demo
+  ansible.builtin.template:
+    src: "templates/env.j2"
+    dest: "{{ nginx_demo_base_path }}/.env"
+    owner: "{{ ansible_facts['user_id'] }}"
+    group: "{{ ansible_facts['user_gid'] }}"
+    mode: "0600"
+
+# Borgmatic backup configuration
+- name: Configure borgmatic backup for Nginx Demo
+  when: nginx_demo_backup_enabled
+  tags: backup
+  block:
+    - name: Create borgmatic configuration for Nginx Demo
+      become: true
+      ansible.builtin.template:
+        src: "templates/borgmatic-nginx_demo.yaml.j2"
+        dest: "{{ borgmatic_config_dir }}/nginx_demo.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0600"
+
+    - name: Initialize borg repository for Nginx Demo
+      become: true
+      ansible.builtin.command:
+        cmd: >-
+          /root/.local/bin/borgmatic
+          --config {{ borgmatic_config_dir }}/nginx_demo.yaml
+          repo-create --encryption {{ borgmatic_encryption_mode | default('repokey-blake2') }}
+      register: nginx_demo_borg_repo_create
+      changed_when: "'repository already exists' not in nginx_demo_borg_repo_create.stderr"
+      failed_when: >
+        nginx_demo_borg_repo_create.rc != 0 and
+        'repository already exists' not in nginx_demo_borg_repo_create.stderr
+
+- name: Make sure nginx_demo service is running
+  ansible.builtin.systemd:
+    state: started
+    daemon_reload: true
+    name: dc@nginx_demo
+    scope: user
+    enabled: true

--- a/ansible/roles/nginx_demo/templates/borgmatic-nginx_demo.yaml.j2
+++ b/ansible/roles/nginx_demo/templates/borgmatic-nginx_demo.yaml.j2
@@ -1,0 +1,180 @@
+# Borgmatic configuration for Nginx Demo backup
+# See https://torsion.org/borgmatic/reference/configuration/ for full reference
+#
+# Backup storage: Hetzner Storage Box via SSH/SFTP
+# Public key authentication is used for SSH connections.
+
+# List of source directories and files to back up. Globs and tildes
+# are expanded. Do not backslash spaces in path names.
+source_directories:
+    - {{ nginx_demo_base_path }}/postgresql
+    - {{ nginx_demo_base_path }}/compose.yaml
+    - {{ nginx_demo_base_path }}/.env
+
+postgresql_databases:
+    - container: nginx-demo-db
+      port: 5432
+      name: {{ nginx_demo_db_name }}
+      username: {{ nginx_demo_db_user }}
+      password: {{ nginx_demo_db_password }}
+
+# Any paths matching these patterns are excluded from backups. Globs
+# and tildes are expanded. Note that a glob pattern must either start
+# with a glob or be an absolute path. Do not backslash spaces in path
+# names. See the output of "borg help patterns" for more details.
+exclude_patterns:
+    - '*.log'
+    - '*.tmp'
+    - 'cache/*'
+
+# Alternate Borg local executable. Defaults to "borg".
+local_path: /root/.local/bin/borg
+
+# A required list of local or remote repositories with paths and
+# optional labels (which can be used with the --repository flag to
+# select a repository). Tildes are expanded. Multiple repositories are
+# backed up to in sequence. Borg placeholders can be used. See the
+# output of "borg help placeholders" for details. See ssh_command for
+# SSH options like identity file or port. If systemd service is used,
+# then add local repository paths in the systemd service file to the
+# ReadWritePaths list.
+repositories:
+    # The local path or Borg URL of the repository.
+    - path: {{ nginx_demo_backup_borgmatic_target }}
+      # An optional label for the repository, used in logging
+      # and to make selecting the repository easier on the
+      # command-line.
+      label: nginx-demo-backup
+
+ssh_command: ssh -i /root/.ssh/backup_storage_box_key -p 23
+
+# Passphrase to unlock the encryption key with. Only use on
+# repositories that were initialized with passphrase/repokey/keyfile
+# encryption. Quote the value if it contains punctuation, so it parses
+# correctly. And backslash any quote or backslash literals as well.
+# Defaults to not set. Supports the "{credential ...}" syntax.
+encryption_passphrase: {{ nginx_demo_backup_encryption_passphrase }}
+
+# Type of compression to use when creating archives. (Compression
+# level can be added separated with a comma, like "zstd,7".) See
+# http://borgbackup.readthedocs.io/en/stable/usage/create.html for
+# details. Defaults to "lz4".
+compression: zstd,10
+
+# Number of daily archives to keep.
+keep_daily: 7
+
+# Number of weekly archives to keep.
+keep_weekly: 4
+
+# Number of monthly archives to keep.
+keep_monthly: 6
+
+# Number of yearly archives to keep.
+keep_yearly: 1
+
+# List of one or more consistency checks to run on a periodic basis
+# (if "frequency" is set) or every time borgmatic runs checks (if
+# "frequency" is omitted).
+checks:
+    # Name of the consistency check to run:
+    #  * "repository" checks the consistency of the
+    # repository.
+    #  * "archives" checks all of the archives.
+    #  * "data" verifies the integrity of the data
+    # within the archives and implies the "archives"
+    # check as well.
+    #  * "spot" checks that some percentage of source
+    # files are found in the most recent archive (with
+    # identical contents).
+    #  * "extract" does an extraction dry-run of the
+    # most recent archive.
+    #  * See "skip_actions" for disabling checks
+    # altogether.
+    - name: repository
+
+      # How frequently to run this type of consistency
+      # check (as a best effort). The value is a number
+      # followed by a unit of time. E.g., "2 weeks" to
+      # run this consistency check no more than every
+      # two weeks for a given repository or "1 month" to
+      # run it no more than monthly. Defaults to
+      # "always": running this check every time checks
+      # are run.
+      frequency: 2 weeks
+
+    - name: archives
+      frequency: 1 month
+
+# Name of the archive to create. Borg placeholders can be used. See
+# the output of "borg help placeholders" for details. Defaults to
+# "{hostname}-{now:%Y-%m-%dT%H:%M:%S.%f}" with Borg 1 and
+# "{hostname}" with Borg 2, as Borg 2 does not require unique
+# archive names; identical archive names form a common "series" that
+# can be targeted together. When running actions like repo-list,
+# info, or check, borgmatic automatically tries to match only
+# archives created with this name format.
+archive_name_format: 'nginx-demo-{now:%Y-%m-%dT%H:%M:%S}'
+
+# List of one or more command hooks to execute, triggered at
+# particular points during borgmatic's execution. For each command
+# hook, specify one of "before" or "after", not both.
+commands:
+    # Name for the point in borgmatic's execution that
+    # the commands should be run before (required if
+    # "after" isn't set):
+    #  * "action" runs before each action for each
+    # repository.
+    #  * "repository" runs before all actions for each
+    # repository.
+    #  * "configuration" runs before all actions and
+    # repositories in the current configuration file.
+    #  * "everything" runs before all configuration
+    # files.
+    - before: action
+
+      # Only trigger the hook when borgmatic is run with
+      # particular actions listed here. Defaults to
+      # running for all actions.
+      when:
+          - create
+
+      # List of one or more shell commands or scripts to
+      # run when this command hook is triggered. Required.
+      run:
+          - echo "Starting Nginx Demo backup at $(date)"
+
+    # Name for the point in borgmatic's execution that
+    # the commands should be run after (required if
+    # "before" isn't set):
+    #  * "action" runs after each action for each
+    # repository.
+    #  * "repository" runs after all actions for each
+    # repository.
+    #  * "configuration" runs after all actions and
+    # repositories in the current configuration file.
+    #  * "everything" runs after all configuration
+    # files.
+    #  * "error" runs after an error occurs.
+    - after: action
+
+      # Only trigger the hook when borgmatic is run with
+      # particular actions listed here. Defaults to
+      # running for all actions.
+      when:
+          - create
+
+      # List of one or more shell commands or scripts to
+      # run when this command hook is triggered. Required.
+      run:
+          - echo "Nginx Demo backup completed at $(date)"
+
+{% if nginx_demo_backup_healthcheck_url is defined and nginx_demo_backup_healthcheck_url %}
+# https://torsion.org/borgmatic/reference/configuration/monitoring/uptime-kuma/
+uptime_kuma:
+    push_url: {{ nginx_demo_backup_healthcheck_url }}
+    states:
+        - start
+        - finish
+        - fail
+{% endif %}

--- a/ansible/roles/nginx_demo/templates/compose.yaml
+++ b/ansible/roles/nginx_demo/templates/compose.yaml
@@ -1,0 +1,46 @@
+---
+services:
+  # Démo/validation du chemin de stockage bloc — LUN iSCSI "demo_test" formaté
+  # et monté par Ansible sous ./postgresql (voir tasks/main.yml), bind-monté
+  # ici comme n'importe quelle autre BDD du repo.
+  nginx-demo-db:
+    image: postgres:18.4-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
+    container_name: nginx-demo-db
+    restart: always
+    environment:
+      POSTGRES_DB: ${NGINX_DEMO_DB_NAME:?Variable is required and must be set}
+      POSTGRES_USER: ${NGINX_DEMO_DB_USER:?Variable is required and must be set}
+      POSTGRES_PASSWORD: ${NGINX_DEMO_DB_PASSWORD:?Variable is required and must be set}
+      PUID: {{ ansible_facts['user_uid'] }}
+      GUID: {{ ansible_facts['user_gid'] }}
+    volumes:
+      - ./postgresql:/var/lib/postgresql
+    networks:
+      - nginx-demo-network
+
+  # Démo/validation du chemin de stockage fichier — contenu statique servi
+  # depuis l'export NFS du NAS (lecture seule).
+  nginx-demo:
+    image: nginx:stable-alpine@sha256:97d490c12ba55b4946b01546d1c3ed324e8d41ab1c9fcb2a616aa470620e5b46
+    container_name: nginx-demo
+    restart: unless-stopped
+    depends_on:
+      - nginx-demo-db
+    volumes:
+      - nginx_demo_html:/usr/share/nginx/html:ro
+    networks:
+      - nginx-demo-network
+      - newt
+
+networks:
+  nginx-demo-network:
+  newt:
+    external: true # Réseau créé par le rôle newt
+
+volumes:
+  nginx_demo_html:
+    driver: local
+    driver_opts:
+      type: "nfs"
+      o: "addr={{ nginx_demo_nas_ip }},nfsvers=3,ro,soft,tcp"
+      device: "{{ nginx_demo_nas_ip }}:{{ nginx_demo_nfs_export }}"

--- a/ansible/roles/nginx_demo/templates/env.j2
+++ b/ansible/roles/nginx_demo/templates/env.j2
@@ -1,0 +1,3 @@
+NGINX_DEMO_DB_NAME={{ nginx_demo_db_name }}
+NGINX_DEMO_DB_USER={{ nginx_demo_db_user }}
+NGINX_DEMO_DB_PASSWORD={{ nginx_demo_db_password }}

--- a/nas-storage-docker/compose.yaml
+++ b/nas-storage-docker/compose.yaml
@@ -1,0 +1,19 @@
+name: nginx-nas
+
+services:
+  nginx:
+    image: docker.io/library/nginx:stable-alpine
+    container_name: nginx
+    ports:
+      - "8080:80"
+    volumes:
+      - nginx_data:/usr/share/nginx/html:ro
+    restart: unless-stopped
+
+volumes:
+  nginx_data:
+    driver: local
+    driver_opts:
+      type: "nfs"
+      o: "addr=192.168.1.137,nfsvers=3,ro,soft,tcp"
+      device: "192.168.1.137:/volume1/apps/nginx-html"

--- a/nas-storage-docker/homelab-storage-architecture.md
+++ b/nas-storage-docker/homelab-storage-architecture.md
@@ -1,0 +1,216 @@
+# Architecture stockage/compute — Ugreen DXP2800 + Proxmox N100
+
+Résumé des décisions prises et de la mise en place, pour référence.
+
+## Principe général
+
+- **NAS Ugreen DXP2800** = stockage uniquement.
+- **VM Proxmox (N100)** = compute pur, jetable/reconstructible à tout moment.
+- Deux protocoles selon la nature de la donnée :
+  - **NFS** pour tout ce qui est fichiers (config, media, uploads) — un export global, un sous-dossier par appli.
+  - **iSCSI + LVM** pour tout ce qui est bases de données — un disque virtuel par service, backé par du bloc, pas de partage de fichiers.
+- **Terraform** provisionne la VM et ses disques (déclaratif, infra).
+- **Ansible** configure l'intérieur de la VM et déploie les stacks Docker Compose (config, applicatif).
+- **Sauvegarde** : un seul mécanisme, les snapshots Btrfs planifiés côté NAS (couvrent fichiers NFS et LUN iSCSI). Proxmox Backup Server reste en bonus optionnel pour le compute, pas pour les données.
+
+Objectif final : la VM ne contient aucun état. `docker compose up` sur une VM neuve + réattachement des volumes NFS/iSCSI = restauration complète.
+
+---
+
+## 1. Stockage fichier — NFS (config, media, appdata)
+
+NAS en NFSv3 uniquement (pas de v4 sur ce modèle). Un seul export global, sous-dossiers par appli — pas besoin d'un export dédié par service, `mountd` résout les sous-chemins d'un export existant même en v3.
+
+### Côté NAS (une fois)
+- Panneau de contrôle → Dossiers partagés → créer `/volume1/apps` (ou réutiliser l'existant).
+- Onglet NFS → règle pour l'IP de la VM, `rw`, `sync`, `no_root_squash` si les conteneurs tournent en root.
+- Arborescence par appli :
+  ```
+  /volume1/apps/
+    ├── nginx-html/
+    ├── nextcloud/{config,data}
+    └── vaultwarden/data
+  ```
+
+### Côté Docker Compose (dans la VM)
+```yaml
+volumes:
+  app_data:
+    driver: local
+    driver_opts:
+      type: "nfs"
+      o: "addr=192.168.1.137,nfsvers=3,rw,hard,tcp,rsize=1048576,wsize=1048576"
+      device: "192.168.1.137:/volume1/apps/<service>"
+```
+
+Points d'attention NFSv3 :
+- `hard` (pas `soft`) pour les données réelles — évite la corruption silencieuse sur coupure réseau. (`soft`/`ro` acceptable seulement pour du contenu statique en lecture seule, comme le `nginx-html` actuel.)
+- Ouvrir le port 111 (portmapper) en plus du 2049 si un firewall existe entre VM et NAS — NFSv3 utilise des ports dynamiques pour `mountd`/`statd`/`lockd`.
+- Pas de mapping d'identité (contrairement à v4) : aligner directement les `PUID`/`PGID` entre NAS et conteneurs.
+- Jamais de fichiers de BDD sur un volume NFS — locking NLM peu fiable → voir section iSCSI.
+
+---
+
+## 2. Stockage bloc — iSCSI + LVM (bases de données, isolation par service)
+
+### Pourquoi
+NFS partage des fichiers ; une BDD veut un disque. Le bloc élimine le problème de locking à la racine — `fsync` et le verrouillage POSIX se comportent comme sur un disque local.
+
+### Mise en place détaillée (une fois, côté NAS puis Proxmox)
+
+Pas d'automatisation possible côté NAS : UGOS Pro n'a pas d'API publique stable (contrairement à Synology/TrueNAS), donc toute cette section se fait à la main, une seule fois.
+
+#### 2.1 — Côté NAS : créer la target et le LUN
+
+1. **Activer le service iSCSI** : Panneau de contrôle / Storage Manager → iSCSI → activer le service si ce n'est pas déjà fait.
+2. **Créer une Target** — c'est le "point d'entrée" réseau, identifié par un IQN (`iqn.2004-04.com.ugreen:nas:docker-pool` par ex., généré automatiquement). Une target = une entité qu'un initiateur (Proxmox) découvre et à laquelle il se connecte.
+   - Activer **CHAP** (utilisateur + mot de passe) sur la target. iSCSI n'a pas d'authentification native comme NFS (qui filtre par IP côté export) — sans CHAP, n'importe quelle machine du réseau qui connaît l'IQN peut monter le LUN en lecture/écriture. Le CHAP est le minimum pour un LUN qui va contenir des BDD.
+   - Si l'interface le permet, restreindre l'accès réseau à la target à la seule IP du nœud Proxmox (N100).
+3. **Créer un LUN** rattaché à cette target :
+   - Choisir le pool de stockage qui l'héberge (le volume RAID/Btrfs existant du DXP2800).
+   - **Thin provisioning** recommandé — n'alloue l'espace qu'à l'usage réel, important sur un NAS 2 baies qui héberge aussi les exports NFS sur le même pool.
+   - Taille : généreuse mais pas au point de saturer le pool (le LVM Proxmox pourra redimensionner la LV du LUN plus tard si besoin, mais agrandir le LUN lui-même côté NAS reste une opération manuelle).
+   - Un seul LUN par target suffit pour ce cas d'usage (`docker-pool`) — inutile de multiplier les targets, la granularité par service se fait plus haut, côté LVM/Terraform.
+4. Vérifier que le port **3260** (port standard iSCSI) est joignable depuis l'IP du Proxmox — pare-feu UGOS si activé.
+
+#### 2.2 — Côté Proxmox : déclarer le storage iSCSI, puis LVM par-dessus
+
+**Via l'interface web** (recommandé pour cette étape ponctuelle, moins sujette aux erreurs de syntaxe CLI) :
+
+1. Datacenter → Storage → Add → **iSCSI** :
+   - Portal = IP du NAS (`192.168.1.137`)
+   - Target = sélectionner l'IQN découvert automatiquement dans la liste déroulante
+   - Renseigner les identifiants CHAP si activés côté NAS
+   - **Content = None** — ce storage brut ne doit pas stocker d'images directement, il sert uniquement de base au layer LVM suivant.
+   - Proxmox gère lui-même le cycle de vie de la session iSCSI (login/logout) à partir de cette déclaration — ne pas faire de `iscsiadm login` manuel en parallèle, ça créerait un conflit de session.
+2. Vérifier que le LUN est bien vu : `pvesm status` (le storage iSCSI apparaît) et `pvesm list nas-iscsi` (liste le/les LUN détecté(s), avec leur identifiant exact — à noter pour l'étape suivante).
+3. Datacenter → Storage → Add → **LVM** :
+   - Base storage = le storage iSCSI créé à l'étape 1 (`nas-iscsi`)
+   - Base volume = le LUN listé par `pvesm list` à l'étape précédente
+   - VG name = `vg-iscsi`
+   - Shared = oui (pas utile avec un seul nœud aujourd'hui, mais ne coûte rien et évite d'y revenir si un second nœud Proxmox est ajouté un jour)
+
+Proxmox exécute alors `pvcreate`/`vgcreate` sur le LUN pour en faire un groupe de volumes LVM.
+
+**Équivalent CLI** (indicatif — vérifier l'identifiant exact du LUN via `pvesm list nas-iscsi` avant de le référencer dans `--base`, le format exact dépend de la sortie) :
+```bash
+pvesm add iscsi nas-iscsi --portal 192.168.1.137 --target iqn.<...>:docker-pool --content none
+pvesm list nas-iscsi   # note l'identifiant exact du LUN affiché
+pvesm add lvm iscsi-lvm --base nas-iscsi:<lun-id> --vgname vg-iscsi --shared 1
+```
+
+Résultat : un groupe de volumes (`iscsi-lvm`) sur lequel Proxmox peut découper une LV **par service** — c'est la granularité "un volume par appli" sans jamais recréer de LUN côté NAS. C'est ce storage `iscsi-lvm` qui est référencé dans le bloc Terraform de la section 3 (`datastore_id = "iscsi-lvm"`).
+
+---
+
+## 3. Provisioning — Terraform (VM + disques par service)
+
+Provider [`bpg/proxmox`](https://registry.terraform.io/providers/bpg/proxmox). Terraform gère la VM et l'attachement des disques ; il ne gère pas la définition du storage `iscsi-lvm` (étape one-shot ci-dessus, pas de ressource Terraform mature pour ça).
+
+```hcl
+terraform {
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = "~> 0.66"
+    }
+  }
+}
+
+provider "proxmox" {
+  endpoint  = "https://proxmox.local:8006/"
+  api_token = var.proxmox_api_token
+  insecure  = true
+}
+
+variable "services" {
+  description = "Un disque iSCSI/LVM par service nécessitant une BDD isolée"
+  type = map(object({
+    size_gb = number
+  }))
+  default = {
+    postgres_nextcloud   = { size_gb = 20 }
+    postgres_vaultwarden = { size_gb = 5 }
+    postgres_authelia    = { size_gb = 5 }
+  }
+}
+
+locals {
+  # scsi0 = disque OS, scsi1+ = un par service
+  service_index = { for idx, name in sort(keys(var.services)) : name => idx + 1 }
+}
+
+resource "proxmox_virtual_environment_vm" "docker_host" {
+  name      = "docker-host"
+  node_name = "pve"
+
+  disk {
+    datastore_id = "local-lvm"
+    interface    = "scsi0"
+    size         = 32
+    file_format  = "raw"
+  }
+
+  dynamic "disk" {
+    for_each = var.services
+    iterator = svc
+    content {
+      datastore_id = "iscsi-lvm"
+      interface    = "scsi${local.service_index[svc.key]}"
+      size         = svc.value.size_gb
+      file_format  = "raw"
+    }
+  }
+
+  agent {
+    enabled = true # nécessaire pour les backups PBS cohérents (fsfreeze)
+  }
+}
+```
+
+Ajouter un service = ajouter une entrée à `var.services` + `terraform apply`. Le disque apparaît dans la VM en `/dev/sdX`, prêt à être formaté par Ansible.
+
+---
+
+## 4. Configuration — Ansible (in-VM)
+
+Playbook complet dans `playbook.yml` (même dossier) : installe `nfs-common`/Docker, formate et monte chaque disque de service (idempotent — ne reformate jamais un disque déjà formaté, donc sûr à relancer), puis déploie les stacks Compose.
+
+Points notables du playbook :
+- `community.general.filesystem` ne reformate pas un disque déjà formaté par défaut — relancer le playbook après ajout d'un nouveau service (nouveau disque Terraform) ne touche pas aux volumes existants.
+- Les chemins `/dev/sdX` du playbook sont indicatifs — pas garantis stables d'un reboot à l'autre ; pour une conf durable, monter par UUID (`blkid`) une fois le premier formatage fait.
+- Les fichiers de config des applis (pas la BDD) continuent de passer par le volume NFS `driver_opts` défini dans chaque `docker-compose.yml`, comme en section 1 — le playbook ne les monte pas explicitement, c'est le driver Docker qui s'en charge au démarrage du conteneur.
+
+---
+
+## 5. Backup — un seul mécanisme, côté NAS
+
+Principe : NFS et iSCSI vivent tous les deux sur le même pool Btrfs du NAS — le LUN iSCSI n'est qu'un fichier thin-provisionné dans ce pool, au même titre que l'export `apps/`. La VM ne contenant aucun état, la sauvegarde se réduit à **un seul pipeline, entièrement côté NAS**, plutôt qu'à croiser un état Proxmox et un état NAS séparés.
+
+| Étape | Mécanisme | Couvre |
+|---|---|---|
+| Snapshot | Snapshots Btrfs planifiés sur le pool NAS (export `apps/` + volume hébergeant le LUN `docker-pool`) | Fichiers et disques de BDD, même planification, même rétention |
+| Cohérence BDD | Aucune action requise | Le snapshot Btrfs est un copy-on-write atomique → image crash-consistante, rejouable via le WAL du moteur (Postgres/MySQL) au redémarrage — même principe qu'un snapshot EBS + replay WAL chez un cloud provider |
+| Hors-site | Un seul job de réplication à partir des mêmes snapshots (`btrfs send/receive` vers un NAS distant, ou `restic`/`rclone`) | Évite que le NAS local soit un point de défaillance unique |
+
+Point de contrôle quotidien unique : *le dernier snapshot NAS existe et a été répliqué hors-site*.
+
+### Filets optionnels (pas des points à surveiller séparément)
+
+- **Proxmox Backup Server** : à garder en bonus pour restaurer vite le *compute* (OS, config VM) — ce n'est plus la source de vérité pour les données, puisque la VM est jetable et que la perdre/recréer ne perd aucune donnée tant que NFS/iSCSI sont intacts côté NAS. Pas besoin de `qemu-guest-agent`/fsfreeze pour la cohérence des disques de BDD, déjà garantie par l'atomicité du snapshot Btrfs + WAL.
+- **Dump logique (`pg_dump`/`mysqldump`)** : utile pour une restauration indépendante de la version/structure du moteur, mais à écrire **dans un dossier de l'export NFS déjà snapshotté** — il est alors capturé automatiquement par le même job Btrfs, sans planification ni vérification séparée.
+
+---
+
+## 6. Checklist de mise en place (ordre d'exécution)
+
+1. NAS : créer l'export NFS `/volume1/apps` + règle NFSv3 pour l'IP de la VM.
+2. NAS : créer la target/LUN iSCSI unique (`docker-pool`).
+3. Proxmox : `pvesm add iscsi` + `pvesm add lvm` sur le LUN.
+4. Terraform : provisionner/mettre à jour la VM avec un disque par service dans `var.services`.
+5. Ansible : formater + monter les nouveaux disques, installer `nfs-common`.
+6. Ansible/Compose : déployer les stacks (NFS pour fichiers, bind mount local pour BDD).
+7. NAS : activer les snapshots Btrfs planifiés sur le pool hébergeant `apps/` + LUN — mécanisme de sauvegarde principal et unique.
+8. NAS : configurer la réplication hors-site à partir de ces mêmes snapshots (`btrfs send/receive`, `restic`/`rclone`).
+9. (Optionnel) Cron : dump logique des BDD écrit dans l'export NFS, pour une restauration indépendante du moteur.
+10. (Optionnel) PBS : en bonus pour la résilience du compute (OS/config VM), pas pour les données.

--- a/nas-storage-docker/playbook.yml
+++ b/nas-storage-docker/playbook.yml
@@ -1,0 +1,79 @@
+---
+# Playbook d'exemple — configuration de la VM Docker host
+# (les disques scsi1+ sont déjà attachés par Terraform avant de lancer ce playbook)
+
+- name: Configure Docker host VM — volumes NFS + iSCSI, déploiement des stacks
+  hosts: docker_host
+  become: true
+
+  vars:
+    nas_ip: 192.168.1.137
+    nfs_apps_root: /volume1/apps
+
+    # Un disque bloc (iSCSI/LVM) par service, attaché par Terraform en scsi1, scsi2, ...
+    # ATTENTION : /dev/sdX n'est pas garanti stable d'un boot à l'autre.
+    # Pour une conf durable, remplacer "device" par l'UUID (blkid) après le premier
+    # formatage, ou par /dev/disk/by-id/scsi-<serial> si Proxmox l'expose de façon stable.
+    block_services:
+      postgres_nextcloud:
+        device: /dev/sdb
+        mount: /mnt/services/postgres_nextcloud
+      postgres_vaultwarden:
+        device: /dev/sdc
+        mount: /mnt/services/postgres_vaultwarden
+      postgres_authelia:
+        device: /dev/sdd
+        mount: /mnt/services/postgres_authelia
+
+  tasks:
+    - name: Installer les paquets nécessaires (client NFS, Docker)
+      ansible.builtin.apt:
+        name:
+          - nfs-common
+          - docker.io
+          - docker-compose-plugin
+        state: present
+        update_cache: true
+
+    - name: Créer le filesystem ext4 sur chaque disque de service
+      # idempotent par défaut : ne reformate pas un disque déjà formaté,
+      # donc sûr à relancer sans perdre les données existantes
+      community.general.filesystem:
+        fstype: ext4
+        dev: "{{ item.value.device }}"
+      loop: "{{ block_services | dict2items }}"
+      loop_control:
+        label: "{{ item.key }}"
+
+    - name: Créer les points de montage
+      ansible.builtin.file:
+        path: "{{ item.value.mount }}"
+        state: directory
+        mode: "0750"
+      loop: "{{ block_services | dict2items }}"
+      loop_control:
+        label: "{{ item.key }}"
+
+    - name: Monter les disques et persister dans fstab
+      ansible.posix.mount:
+        path: "{{ item.value.mount }}"
+        src: "{{ item.value.device }}"
+        fstype: ext4
+        opts: defaults,nofail
+        state: mounted
+      loop: "{{ block_services | dict2items }}"
+      loop_control:
+        label: "{{ item.key }}"
+
+    - name: Déployer les fichiers docker-compose.yml de chaque stack
+      ansible.builtin.copy:
+        src: "compose/{{ item }}/docker-compose.yml"
+        dest: "/opt/{{ item }}/docker-compose.yml"
+        mode: "0644"
+      loop: "{{ block_services.keys() | list }}"
+
+    - name: Lancer chaque stack
+      community.docker.docker_compose_v2:
+        project_src: "/opt/{{ item }}"
+        state: present
+      loop: "{{ block_services.keys() | list }}"

--- a/tofu/pangolin_config/roles.tf
+++ b/tofu/pangolin_config/roles.tf
@@ -16,7 +16,8 @@ locals {
     "sparky-fitness",
     "homelable",
     "gramps",
-    "dawarich"
+    "dawarich",
+    "nginx-demo"
   ]
 }
 

--- a/tofu/pangolin_config/website_nginx_demo.tf
+++ b/tofu/pangolin_config/website_nginx_demo.tf
@@ -1,0 +1,81 @@
+resource "pangolin_resource" "nginx_demo" {
+  name        = "Nginx Demo"
+  subdomain   = "nginx"
+  domain_id   = local.domain_ids["sylvain.cloud"]
+  protocol    = "tcp"
+  sso         = true
+  apply_rules = true
+}
+
+resource "pangolin_resource_role" "nginx_demo" {
+  resource_id = pangolin_resource.nginx_demo.id
+  role_id     = pangolin_role.apps["nginx-demo"].id
+}
+
+resource "pangolin_target" "nginx_demo" {
+  resource_id = pangolin_resource.nginx_demo.id
+  site_id     = pangolin_site.proxmox_docker.id
+  ip          = "nginx-demo"
+  port        = 80
+  method      = "http"
+
+  hc_enabled             = true
+  hc_hostname            = "nginx-demo"
+  hc_path                = "/"
+  hc_method              = "GET"
+  hc_status              = 200
+  hc_headers             = []
+  hc_interval            = 30
+  hc_unhealthy_interval  = 10
+  hc_timeout             = 5
+  hc_healthy_threshold   = 2
+  hc_unhealthy_threshold = 3
+}
+
+resource "pangolin_resource_access_token" "nginx_demo" {
+  resource_id = pangolin_resource.nginx_demo.id
+  title       = "Healthcheck ${pangolin_resource.nginx_demo.name}"
+}
+
+output "nginx_demo_access_token" {
+  description = "NGINX_DEMO - Token d'accès pour les healthchecks"
+  value = jsonencode({
+    id    = pangolin_resource_access_token.nginx_demo.id,
+    token = pangolin_resource_access_token.nginx_demo.token
+  })
+  sensitive = true
+}
+
+resource "uptimekuma_monitor_http" "nginx_demo" {
+  name            = "Healthcheck ${pangolin_resource.nginx_demo.name}"
+  url             = "https://${pangolin_resource.nginx_demo.full_domain}"
+  interval        = 60
+  timeout         = 30
+  max_retries     = 2
+  retry_interval  = 60
+  resend_interval = 0
+  active          = true
+  method          = "GET"
+  headers = jsonencode({
+    "P-Access-Token-Id" = tostring(pangolin_resource_access_token.nginx_demo.id),
+    "P-Access-Token"    = pangolin_resource_access_token.nginx_demo.token
+  })
+  expiry_notification = true
+  tags                = [{ tag_id : uptimekuma_tag.self_hosted.id }]
+}
+
+resource "uptimekuma_monitor_push" "backup_nginx_demo" {
+  name = "Backup ${pangolin_resource.nginx_demo.name}"
+
+  interval = 60 * 60 * 24
+
+  retry_interval = 20
+  active         = true
+  tags           = [{ tag_id : uptimekuma_tag.backup.id }]
+}
+
+output "uptime_backup_nginx_demo_url" {
+  description = "NGINX_DEMO - URL pour envoyer les heartbeats push"
+  value       = "${local.uptimekuma_endpoint}/api/push/${uptimekuma_monitor_push.backup_nginx_demo.push_token}"
+  sensitive   = true
+}

--- a/tofu/proxmox/proxmox_docker_vm.tf
+++ b/tofu/proxmox/proxmox_docker_vm.tf
@@ -54,6 +54,12 @@ resource "proxmox_virtual_environment_file" "docker_user_config" {
   }
 }
 
+locals {
+  # scsi0, scsi1, ... — un disque par service, ordre alphabétique stable
+  # d'un apply à l'autre tant qu'on n'insère pas de nouvelle clé au milieu.
+  docker_vm_data_disk_index = { for idx, name in sort(keys(var.docker_vm_data_disks)) : name => idx }
+}
+
 resource "proxmox_virtual_environment_vm" "docker" {
   depends_on = [
     proxmox_virtual_environment_file.docker_user_config,
@@ -83,6 +89,22 @@ resource "proxmox_virtual_environment_vm" "docker" {
     discard      = "on"
     ssd          = false
     size         = var.docker_vm.disk_size
+  }
+
+  # Un disque par service listé dans var.docker_vm_data_disks, sur le storage
+  # Proxmox "iscsi-lvm" (LUN iSCSI NAS partagé, une LV par service). Ansible
+  # formate/monte ensuite ce disque brut sous /dev/sdX dans la VM.
+  dynamic "disk" {
+    for_each = var.docker_vm_data_disks
+    iterator = svc
+    content {
+      datastore_id = "iscsi-lvm"
+      interface    = "scsi${local.docker_vm_data_disk_index[svc.key]}"
+      size         = svc.value.size_gb
+      file_format  = "raw"
+      ssd          = false
+      discard      = "on"
+    }
   }
 
   lifecycle {

--- a/tofu/proxmox/terraform.tfvars
+++ b/tofu/proxmox/terraform.tfvars
@@ -28,3 +28,11 @@ docker_vm = {
   storage   = "local-lvm"
   bridge    = "vmbr0"
 }
+
+# Un disque par service nécessitant une BDD isolée sur le storage Proxmox
+# "iscsi-lvm" (LUN iSCSI NAS "docker-pool" — voir
+# nas-storage-docker/homelab-storage-architecture.md, section 2). Prérequis :
+# le storage "iscsi-lvm" doit déjà exister côté Proxmox avant `tofu apply`.
+docker_vm_data_disks = {
+  demo_test = { size_gb = 10 }
+}

--- a/tofu/proxmox/variables.tf
+++ b/tofu/proxmox/variables.tf
@@ -62,3 +62,17 @@ variable "docker_vm" {
   })
   default = {}
 }
+
+variable "docker_vm_data_disks" {
+  description = <<-EOT
+    Disques par service nécessitant une BDD isolée du reste de la VM, backés
+    par le storage Proxmox "iscsi-lvm" (LVM sur le LUN iSCSI unique du NAS,
+    voir nas-storage-docker/homelab-storage-architecture.md). Ce storage est
+    créé une fois, à la main, côté Proxmox (pvesm add iscsi / pvesm add lvm)
+    — pas de ressource Tofu pour cette étape.
+  EOT
+  type = map(object({
+    size_gb = number
+  }))
+  default = {}
+}


### PR DESCRIPTION
## Summary

Implémente de bout en bout l'architecture stockage documentée dans `nas-storage-docker/homelab-storage-architecture.md` (NFS pour les fichiers, iSCSI+LVM pour les BDD) sur un premier service réel, exposé sur `nginx.sylvain.cloud` :

- **`tofu/proxmox`** : nouvelle variable `docker_vm_data_disks`, disque dynamique attaché sur le storage Proxmox `iscsi-lvm`, entrée `demo_test` (10 Go) dans `terraform.tfvars`.
- **`tofu/pangolin_config`** : routing + healthcheck + SSO pour `nginx-demo` (nouveau `website_nginx_demo.tf`).
- **`ansible/roles/nginx_demo`** (nouveau rôle) : `nginx` (volume statique NFS en lecture seule) + `postgres` (bind mount sur le disque `demo_test`). Le disque est formaté une seule fois avec un UUID fixé (`mkfs -U`), puis toujours remonté par UUID plutôt que par `/dev/sdX` — robuste si un futur second disque iSCSI/LVM décale la numérotation `/dev/sdX` au reboot.
- **`ansible/roles/docker_service`** : installe `nfs-common`, requis par `dockerd` pour les volumes Docker avec `driver_opts` NFS (générique, réutilisable par toute future appli NFS).
- **`docker.yml` / `host_vars` / `backups`** : câblage standard healthcheck + backup Borgmatic + enregistrement du rôle.
- **`nas-storage-docker/`** : commit du doc d'architecture + des exemples (`compose.yaml`, `playbook.yml`) qui servent de référence à cette implémentation.

## Étapes manuelles requises avant `tofu apply` / `ansible-playbook` (non automatisables — voir `nas-storage-docker/homelab-storage-architecture.md` §2)

1. **NAS** : créer le sous-dossier `/volume1/apps/nginx_demo` sous l'export NFS existant (la règle NFSv3 pour l'IP `192.168.1.216` doit déjà l'autoriser).
2. **Proxmox** : le storage `iscsi-lvm` doit déjà exister (`pvesm add iscsi` puis `pvesm add lvm` sur le LUN `docker-pool` du NAS) — sinon `tofu apply` sur `tofu/proxmox` échoue à l'attachement du disque `demo_test`.

## Ordre d'apply

```bash
cd tofu/proxmox && tofu plan && tofu apply        # attache le disque demo_test (scsi0)
cd ../pangolin_config && tofu plan && tofu apply  # crée la route + le healthcheck

cd ../../ansible
ansible-playbook -i inventory/hosts docker.yml --check --tags nginx_demo,app
ansible-playbook -i inventory/hosts docker.yml --tags nginx_demo,app
```

## Test plan

- [x] `tofu validate` sur `tofu/proxmox` et `tofu/pangolin_config`
- [x] `ansible-lint` sur `ansible/roles/nginx_demo` et `ansible/roles/docker_service` (0 erreur)
- [x] `ansible-playbook docker.yml --syntax-check`
- [ ] Étapes manuelles NAS/Proxmox ci-dessus effectuées
- [ ] `tofu apply` (proxmox puis pangolin_config)
- [ ] `ansible-playbook docker.yml --tags nginx_demo,app` en réel
- [ ] `curl -I https://nginx.sylvain.cloud` répond, monitor Uptime Kuma vert

🤖 Generated with [Claude Code](https://claude.com/claude-code)