### PR TITLE
feat: add ActualBudget app

### DIFF
--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -42,6 +42,7 @@
         homelable_backup_healthcheck_url: "{{ terraform_outputs.uptime_backup_homelable_url.value | default('') }}"
         gramps_backup_healthcheck_url: "{{ terraform_outputs.uptime_backup_gramps_url.value | default('') }}"
         dawarich_backup_healthcheck_url: "{{ terraform_outputs.uptime_backup_dawarich_url.value | default('') }}"
+        actualbudget_backup_healthcheck_url: "{{ terraform_outputs.uptime_backup_actualbudget_url.value | default('') }}"
       vars:
         terraform_outputs: "{{ (terraform_state_raw.contents | from_json).outputs | default({}) }}"
 
@@ -85,3 +86,5 @@
       tags: gramps,app
     - role: dawarich
       tags: dawarich,app
+    - role: actualbudget
+      tags: actualbudget,app

--- a/ansible/host_vars/backups/variables.yaml
+++ b/ansible/host_vars/backups/variables.yaml
@@ -16,3 +16,4 @@ backup_folders:
   - "homelable"
   - "gramps"
   - "dawarich"
+  - "actualbudget"

--- a/ansible/host_vars/docker/variables.yaml
+++ b/ansible/host_vars/docker/variables.yaml
@@ -55,3 +55,7 @@ gramps_backup_encryption_passphrase: "{{ backup_passphrase }}"
 dawarich_backup_enabled: true
 dawarich_backup_borgmatic_target: "ssh://{{ backup_storage_box_username }}@{{ backup_storage_box_hostname }}/{{ backup_storage_box_path }}/dawarich"
 dawarich_backup_encryption_passphrase: "{{ backup_passphrase }}"
+
+actualbudget_backup_enabled: true
+actualbudget_backup_borgmatic_target: "ssh://{{ backup_storage_box_username }}@{{ backup_storage_box_hostname }}/{{ backup_storage_box_path }}/actualbudget"
+actualbudget_backup_encryption_passphrase: "{{ backup_passphrase }}"

--- a/ansible/roles/actualbudget/defaults/main.yml
+++ b/ansible/roles/actualbudget/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+actualbudget_base_path: "{{ docker_base_path }}/actualbudget"
+actualbudget_domain: budget.sylvain.cloud
+
+# Borgmatic backup configuration
+actualbudget_backup_enabled: true
+actualbudget_backup_borgmatic_target: ""
+actualbudget_backup_encryption_passphrase: ""
+actualbudget_backup_healthcheck_url: ""

--- a/ansible/roles/actualbudget/handlers/main.yml
+++ b/ansible/roles/actualbudget/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart actualbudget
+  ansible.builtin.systemd:
+    name: dc@actualbudget
+    scope: user
+    state: restarted

--- a/ansible/roles/actualbudget/tasks/main.yml
+++ b/ansible/roles/actualbudget/tasks/main.yml
@@ -1,0 +1,55 @@
+---
+- name: Ensure ActualBudget app folders exist
+  loop:
+    - "{{ actualbudget_base_path }}"
+    - "{{ actualbudget_base_path }}/data"
+  ansible.builtin.file:
+    mode: "0755"
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ ansible_facts['user_id'] }}"
+    group: "{{ ansible_facts['user_gid'] }}"
+
+- name: Template compose configuration
+  notify: Restart actualbudget
+  ansible.builtin.template:
+    src: "templates/compose.yaml"
+    dest: "{{ actualbudget_base_path }}/compose.yaml"
+    owner: "{{ ansible_facts['user_id'] }}"
+    group: "{{ ansible_facts['user_gid'] }}"
+    mode: "0644"
+
+# Borgmatic backup configuration
+- name: Configure borgmatic backup for ActualBudget
+  when: actualbudget_backup_enabled
+  tags: backup
+  block:
+    - name: Create borgmatic configuration for ActualBudget
+      become: true
+      ansible.builtin.template:
+        src: "templates/borgmatic-actualbudget.yaml.j2"
+        dest: "{{ borgmatic_config_dir }}/actualbudget.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0600"
+
+    - name: Initialize borg repository for ActualBudget
+      become: true
+      ansible.builtin.command:
+        cmd: >-
+          /root/.local/bin/borgmatic
+          --config {{ borgmatic_config_dir }}/actualbudget.yaml
+          repo-create --encryption {{ borgmatic_encryption_mode | default('repokey-blake2') }}
+      register: actualbudget_borg_repo_create
+      changed_when: "'repository already exists' not in actualbudget_borg_repo_create.stderr"
+      failed_when: >
+        actualbudget_borg_repo_create.rc != 0 and
+        'repository already exists' not in actualbudget_borg_repo_create.stderr
+
+- name: Make sure actualbudget service is running
+  ansible.builtin.systemd:
+    state: started
+    daemon_reload: true
+    name: dc@actualbudget
+    scope: user
+    enabled: true

--- a/ansible/roles/actualbudget/templates/borgmatic-actualbudget.yaml.j2
+++ b/ansible/roles/actualbudget/templates/borgmatic-actualbudget.yaml.j2
@@ -1,0 +1,172 @@
+# Borgmatic configuration for ActualBudget backup
+# See https://torsion.org/borgmatic/reference/configuration/ for full reference
+#
+# Backup storage: Hetzner Storage Box via SSH/SFTP
+# Public key authentication is used for SSH connections.
+
+# List of source directories and files to back up. Globs and tildes
+# are expanded. Do not backslash spaces in path names.
+source_directories:
+    - {{ actualbudget_base_path }}/data
+    - {{ actualbudget_base_path }}/compose.yaml
+
+# Any paths matching these patterns are excluded from backups. Globs
+# and tildes are expanded. Note that a glob pattern must either start
+# with a glob or be an absolute path. Do not backslash spaces in path
+# names. See the output of "borg help patterns" for more details.
+exclude_patterns:
+    - '*.log'
+    - '*.tmp'
+    - 'cache/*'
+
+# Alternate Borg local executable. Defaults to "borg".
+local_path: /root/.local/bin/borg
+
+# A required list of local or remote repositories with paths and
+# optional labels (which can be used with the --repository flag to
+# select a repository). Tildes are expanded. Multiple repositories are
+# backed up to in sequence. Borg placeholders can be used. See the
+# output of "borg help placeholders" for details. See ssh_command for
+# SSH options like identity file or port. If systemd service is used,
+# then add local repository paths in the systemd service file to the
+# ReadWritePaths list.
+repositories:
+    # The local path or Borg URL of the repository.
+    - path: {{ actualbudget_backup_borgmatic_target }}
+      # An optional label for the repository, used in logging
+      # and to make selecting the repository easier on the
+      # command-line.
+      label: actualbudget-backup
+
+ssh_command: ssh -i /root/.ssh/backup_storage_box_key -p 23
+
+# Passphrase to unlock the encryption key with. Only use on
+# repositories that were initialized with passphrase/repokey/keyfile
+# encryption. Quote the value if it contains punctuation, so it parses
+# correctly. And backslash any quote or backslash literals as well.
+# Defaults to not set. Supports the "{credential ...}" syntax.
+encryption_passphrase: {{ actualbudget_backup_encryption_passphrase }}
+
+# Type of compression to use when creating archives. (Compression
+# level can be added separated with a comma, like "zstd,7".) See
+# http://borgbackup.readthedocs.io/en/stable/usage/create.html for
+# details. Defaults to "lz4".
+compression: zstd,10
+
+# Number of daily archives to keep.
+keep_daily: 7
+
+# Number of weekly archives to keep.
+keep_weekly: 4
+
+# Number of monthly archives to keep.
+keep_monthly: 6
+
+# Number of yearly archives to keep.
+keep_yearly: 1
+
+# List of one or more consistency checks to run on a periodic basis
+# (if "frequency" is set) or every time borgmatic runs checks (if
+# "frequency" is omitted).
+checks:
+    # Name of the consistency check to run:
+    #  * "repository" checks the consistency of the
+    # repository.
+    #  * "archives" checks all of the archives.
+    #  * "data" verifies the integrity of the data
+    # within the archives and implies the "archives"
+    # check as well.
+    #  * "spot" checks that some percentage of source
+    # files are found in the most recent archive (with
+    # identical contents).
+    #  * "extract" does an extraction dry-run of the
+    # most recent archive.
+    #  * See "skip_actions" for disabling checks
+    # altogether.
+    - name: repository
+
+      # How frequently to run this type of consistency
+      # check (as a best effort). The value is a number
+      # followed by a unit of time. E.g., "2 weeks" to
+      # run this consistency check no more than every
+      # two weeks for a given repository or "1 month" to
+      # run it no more than monthly. Defaults to
+      # "always": running this check every time checks
+      # are run.
+      frequency: 2 weeks
+
+    - name: archives
+      frequency: 1 month
+
+# Name of the archive to create. Borg placeholders can be used. See
+# the output of "borg help placeholders" for details. Defaults to
+# "{hostname}-{now:%Y-%m-%dT%H:%M:%S.%f}" with Borg 1 and
+# "{hostname}" with Borg 2, as Borg 2 does not require unique
+# archive names; identical archive names form a common "series" that
+# can be targeted together. When running actions like repo-list,
+# info, or check, borgmatic automatically tries to match only
+# archives created with this name format.
+archive_name_format: 'actualbudget-{now:%Y-%m-%dT%H:%M:%S}'
+
+# List of one or more command hooks to execute, triggered at
+# particular points during borgmatic's execution. For each command
+# hook, specify one of "before" or "after", not both.
+commands:
+    # Name for the point in borgmatic's execution that
+    # the commands should be run before (required if
+    # "after" isn't set):
+    #  * "action" runs before each action for each
+    # repository.
+    #  * "repository" runs before all actions for each
+    # repository.
+    #  * "configuration" runs before all actions and
+    # repositories in the current configuration file.
+    #  * "everything" runs before all configuration
+    # files.
+    - before: action
+
+      # Only trigger the hook when borgmatic is run with
+      # particular actions listed here. Defaults to
+      # running for all actions.
+      when:
+          - create
+
+      # List of one or more shell commands or scripts to
+      # run when this command hook is triggered. Required.
+      run:
+          - echo "Starting ActualBudget backup at $(date)"
+
+    # Name for the point in borgmatic's execution that
+    # the commands should be run after (required if
+    # "before" isn't set):
+    #  * "action" runs after each action for each
+    # repository.
+    #  * "repository" runs after all actions for each
+    # repository.
+    #  * "configuration" runs after all actions and
+    # repositories in the current configuration file.
+    #  * "everything" runs after all configuration
+    # files.
+    #  * "error" runs after an error occurs.
+    - after: action
+
+      # Only trigger the hook when borgmatic is run with
+      # particular actions listed here. Defaults to
+      # running for all actions.
+      when:
+          - create
+
+      # List of one or more shell commands or scripts to
+      # run when this command hook is triggered. Required.
+      run:
+          - echo "ActualBudget backup completed at $(date)"
+
+{% if actualbudget_backup_healthcheck_url is defined and actualbudget_backup_healthcheck_url %}
+# https://torsion.org/borgmatic/reference/configuration/monitoring/uptime-kuma/
+uptime_kuma:
+    push_url: {{ actualbudget_backup_healthcheck_url }}
+    states:
+        - start
+        - finish
+        - fail
+{% endif %}

--- a/ansible/roles/actualbudget/templates/compose.yaml
+++ b/ansible/roles/actualbudget/templates/compose.yaml
@@ -1,0 +1,14 @@
+---
+services:
+  actualbudget:
+    image: docker.io/actualbudget/actual-server:26.8.0@sha256:0b300f370dba85a74998a953736a831bd931cc8cb76c0d8ceac3d3fd288dfd4d
+    container_name: actualbudget
+    restart: unless-stopped
+    volumes:
+      - ./data:/data
+    networks:
+      - newt
+
+networks:
+  newt:
+    external: true

--- a/tofu/pangolin_config/roles.tf
+++ b/tofu/pangolin_config/roles.tf
@@ -15,7 +15,8 @@ locals {
     "flip-planning",
     "homelable",
     "gramps",
-    "dawarich"
+    "dawarich",
+    "actualbudget"
   ]
 }
 

--- a/tofu/pangolin_config/website_actualbudget.tf
+++ b/tofu/pangolin_config/website_actualbudget.tf
@@ -1,0 +1,81 @@
+resource "pangolin_resource" "actualbudget" {
+  name        = "ActualBudget"
+  subdomain   = "budget"
+  domain_id   = local.domain_ids["sylvain.cloud"]
+  protocol    = "tcp"
+  sso         = true
+  apply_rules = true
+}
+
+resource "pangolin_resource_role" "actualbudget" {
+  resource_id = pangolin_resource.actualbudget.id
+  role_id     = pangolin_role.apps["actualbudget"].id
+}
+
+resource "pangolin_target" "actualbudget" {
+  resource_id = pangolin_resource.actualbudget.id
+  site_id     = pangolin_site.proxmox_docker.id
+  ip          = "actualbudget"
+  port        = 5006
+  method      = "http"
+
+  hc_enabled             = true
+  hc_hostname            = "actualbudget"
+  hc_path                = "/"
+  hc_method              = "GET"
+  hc_status              = 200
+  hc_headers             = []
+  hc_interval            = 30
+  hc_unhealthy_interval  = 10
+  hc_timeout             = 5
+  hc_healthy_threshold   = 2
+  hc_unhealthy_threshold = 3
+}
+
+resource "pangolin_resource_access_token" "actualbudget" {
+  resource_id = pangolin_resource.actualbudget.id
+  title       = "Healthcheck ${pangolin_resource.actualbudget.name}"
+}
+
+output "actualbudget_access_token" {
+  description = "ACTUALBUDGET - Token d'accès pour les healthchecks"
+  value = jsonencode({
+    id    = pangolin_resource_access_token.actualbudget.id,
+    token = pangolin_resource_access_token.actualbudget.token
+  })
+  sensitive = true
+}
+
+resource "uptimekuma_monitor_http" "actualbudget" {
+  name            = "Healthcheck ${pangolin_resource.actualbudget.name}"
+  url             = "https://${pangolin_resource.actualbudget.full_domain}"
+  interval        = 60
+  timeout         = 30
+  max_retries     = 2
+  retry_interval  = 60
+  resend_interval = 0
+  active          = true
+  method          = "GET"
+  headers = jsonencode({
+    "P-Access-Token-Id" = tostring(pangolin_resource_access_token.actualbudget.id),
+    "P-Access-Token"    = pangolin_resource_access_token.actualbudget.token
+  })
+  expiry_notification = true
+  tags                = [{ tag_id : uptimekuma_tag.self_hosted.id }]
+}
+
+resource "uptimekuma_monitor_push" "backup_actualbudget" {
+  name = "Backup ${pangolin_resource.actualbudget.name}"
+
+  interval = 60 * 60 * 24
+
+  retry_interval = 20
+  active         = true
+  tags           = [{ tag_id : uptimekuma_tag.backup.id }]
+}
+
+output "uptime_backup_actualbudget_url" {
+  description = "ACTUALBUDGET - URL pour envoyer les heartbeats push"
+  value       = "${local.uptimekuma_endpoint}/api/push/${uptimekuma_monitor_push.backup_actualbudget.push_token}"
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary
- Scaffold the `actualbudget` Ansible role (compose, borgmatic backup, docker.yml wiring) based on the official Docker install instructions (https://actualbudget.org/docs/install/docker)
- Add Pangolin routing/SSO/healthcheck + backup-push monitor via Tofu (`budget.sylvain.cloud`)
- Wire `actualbudget` into the backup folder list and host_vars

Closes #63

## Test plan
- [x] `ansible-lint roles/actualbudget` passes
- [x] `ansible-playbook docker.yml --syntax-check` passes
- [x] `tofu fmt -recursive && tofu validate` pass in `tofu/pangolin_config`
- [x] `tofu plan` shows the expected `actualbudget` resources being created
- [ ] `tofu apply` then `ansible-playbook -i inventory/hosts docker.yml --tags actualbudget,app` (not run — nothing was applied/deployed as requested)
- [ ] Verify `https://budget.sylvain.cloud` loads and Uptime Kuma healthcheck/backup-push monitors go green after apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)