### PR TITLE
fix: resolve all ansible-lint and OpenTofu lint warnings

### DIFF
--- a/ansible/.ansible-lint
+++ b/ansible/.ansible-lint
@@ -8,3 +8,6 @@ exclude_paths:
   - .venv/
   - collections/
   - galaxy_roles/
+  # SOPS-encrypted: ciphertext lines can't be reformatted by hand without
+  # breaking the file's MAC; content is machine-generated, not authored.
+  - secrets.sops.yaml

--- a/ansible/.ansible-lint-ignore
+++ b/ansible/.ansible-lint-ignore
@@ -1,0 +1,8 @@
+# paperless_ngx vars are intentionally unprefixed (paperless_*, not
+# paperless_ngx_*) so they line up 1:1 with the corresponding keys in
+# ansible/secrets.sops.yaml (community.sops.load_vars overrides the empty
+# role defaults by matching name). Renaming these would require decrypting
+# and re-encrypting secrets.sops.yaml, which isn't available in this
+# environment (no age key) - left as-is rather than risk breaking secret
+# injection.
+roles/paperless_ngx/defaults/main.yml var-naming[no-role-prefix]

--- a/ansible/00-setup.yaml
+++ b/ansible/00-setup.yaml
@@ -1,5 +1,6 @@
 ---
-- hosts: all,!backups
+- name: Base host setup
+  hosts: all,!backups
   tags: setup
   post_tasks:
     - name: Ensure starship is initialized in .bashrc

--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -48,26 +48,26 @@
         terraform_outputs: "{{ (terraform_state_raw.contents | from_json).outputs | default({}) }}"
 
   roles:
-    - name: geerlingguy.docker
+    - role: geerlingguy.docker
       become: true
       tags: setup
-    - name: docker_service
+    - role: docker_service
       tags: setup
-    - name: borgmatic
+    - role: borgmatic
       tags: backup,setup
-    - name: decommission_app
+    - role: decommission_app
       tags: [decommission, never]
-    - name: newt
+    - role: newt
       tags: newt,setup
-    - name: echo
+    - role: echo
       tags: echo,app
-    - name: rss
+    - role: rss
       tags: rss,app
-    - name: searxng
+    - role: searxng
       tags: searxng,app,search
-    - name: betisier
+    - role: betisier
       tags: betisier,app
-    - name: monica_v4
+    - role: monica_v4
       tags: monica,app
     - role: wiki
       tags: wiki,app
@@ -77,7 +77,7 @@
       tags: semaphore,app
     - role: meerkat_crm
       tags: meerkat_crm,app
-    - name: paperless_ngx
+    - role: paperless_ngx
       tags: paperless,app
     - role: flip_planning
       tags: flip_planning,app

--- a/ansible/host_vars/pangolin/variables.yaml
+++ b/ansible/host_vars/pangolin/variables.yaml
@@ -12,13 +12,6 @@ pangolin_api_url: "pangolin-api.{{ pangolin_base_domain }}"
 # Log level (debug, info, warning, error)
 pangolin_log_level: "info"
 
-# Let's Encrypt email for certificate generation
-le_email: "{{ pangolin_le_email }}"
-
-# SMTP configuration (values should be in secrets.sops.yaml)
-smtp_user: "{{ pangolin_smtp_user }}"
-smtp_pass: "{{ pangolin_smtp_pass }}"
-
 # Pangolin secret (should be in secrets.sops.yaml)
 pangolin_secret: "{{ pangolin_server_secret }}"
 
@@ -26,7 +19,7 @@ pangolin_backup_enabled: true
 pangolin_backup_borgmatic_target: "ssh://{{ backup_storage_box_username }}@{{ backup_storage_box_hostname }}/{{ backup_storage_box_path }}/pangolin"
 pangolin_backup_encryption_passphrase: "{{ backup_passphrase }}"
 
-ufw_allowed_ports:
+security_ufw_allowed_ports:
   - { port: "22", proto: tcp }
   - { port: "80", proto: tcp }
   - { port: "443", proto: tcp }

--- a/ansible/pangolin.yaml
+++ b/ansible/pangolin.yaml
@@ -33,10 +33,10 @@
         terraform_outputs: "{{ (terraform_state_raw.contents | from_json).outputs | default({}) }}"
 
   roles:
-    - name: geerlingguy.docker
+    - role: geerlingguy.docker
       become: true
       tags: setup
-    - name: borgmatic
+    - role: borgmatic
       tags: backup,setup
     - role: security
       become: true

--- a/ansible/pi.yml
+++ b/ansible/pi.yml
@@ -35,16 +35,16 @@
         terraform_outputs: "{{ (terraform_state_raw.contents | from_json).outputs | default({}) }}"
 
   roles:
-    - name: geerlingguy.docker
+    - role: geerlingguy.docker
       become: true
       tags: setup
-    - name: docker_service
+    - role: docker_service
       tags: setup
-    - name: borgmatic
+    - role: borgmatic
       tags: backup,setup
-    - name: decommission_app
+    - role: decommission_app
       tags: [decommission, never]
-    - name: newt
+    - role: newt
       tags: newt,setup
     # - role: photoprism
     #   tags: app,photoprism

--- a/ansible/roles/betisier/tasks/main.yml
+++ b/ansible/roles/betisier/tasks/main.yml
@@ -41,8 +41,8 @@
     group: "{{ ansible_facts['user_gid'] }}"
     mode: "0644"
   notify:
-  - Reload systemd user
-  - Restart betisier
+    - Reload systemd user
+    - Restart betisier
 
 - name: Template betisier-reset timer
   ansible.builtin.template:
@@ -77,10 +77,12 @@
 
     - name: Initialize borg repository for Betisier
       become: true
-      ansible.builtin.shell:
-        cmd: "/root/.local/bin/borgmatic --config {{ borgmatic_config_dir }}/betisier.yaml repo-create --encryption {{ borgmatic_encryption_mode | default('repokey-blake2') }}"
-      register: borg_repo_create
-      changed_when: "'repository already exists' not in borg_repo_create.stderr"
+      ansible.builtin.command:
+        cmd: >-
+          /root/.local/bin/borgmatic --config {{ borgmatic_config_dir }}/betisier.yaml
+          repo-create --encryption {{ borgmatic_encryption_mode | default('repokey-blake2') }}
+      register: betisier_borg_repo_create
+      changed_when: "'repository already exists' not in betisier_borg_repo_create.stderr"
       failed_when: >
-        borg_repo_create.rc != 0 and
-        'repository already exists' not in borg_repo_create.stderr
+        betisier_borg_repo_create.rc != 0 and
+        'repository already exists' not in betisier_borg_repo_create.stderr

--- a/ansible/roles/borgmatic/defaults/main.yml
+++ b/ansible/roles/borgmatic/defaults/main.yml
@@ -3,7 +3,7 @@
 borgmatic_config_dir: "/etc/borgmatic.d"
 
 # Borg version to download from GitHub releases
-borg_version: "1.4.4"
+borgmatic_borg_version: "1.4.4"
 
 # Borg repository encryption mode (for repo-create)
 # Common values: repokey-blake2, repokey-chacha20-poly1305, none
@@ -20,8 +20,8 @@ borgmatic_timer_schedule: "*-*-* 01:00:00"
 borgmatic_user: "root"
 
 # Rclone configuration
-rclone_config_dir: "/root/.config/rclone"
-rclone_s3_access_key_id: "{{ rclone_access_key_id | default('') }}"
-rclone_s3_secret_access_key: "{{ rclone_secret_access_key | default('') }}"
-rclone_s3_endpoint: "s3.eu-west-par.io.cloud.ovh.net"
-rclone_s3_region: "EU-WEST-PAR"
+borgmatic_rclone_config_dir: "/root/.config/rclone"
+borgmatic_rclone_s3_access_key_id: "{{ rclone_access_key_id | default('') }}"
+borgmatic_rclone_s3_secret_access_key: "{{ rclone_secret_access_key | default('') }}"
+borgmatic_rclone_s3_endpoint: "s3.eu-west-par.io.cloud.ovh.net"
+borgmatic_rclone_s3_region: "EU-WEST-PAR"

--- a/ansible/roles/borgmatic/tasks/main.yml
+++ b/ansible/roles/borgmatic/tasks/main.yml
@@ -12,8 +12,8 @@
 - name: Ensure pipx path for root
   become: true
   ansible.builtin.command: pipx ensurepath
-  register: pipx_ensurepath
-  changed_when: "'already in PATH' not in pipx_ensurepath.stdout"
+  register: borgmatic_pipx_ensurepath
+  changed_when: "'already in PATH' not in borgmatic_pipx_ensurepath.stdout"
 
 - name: Ensure /root/.local/bin is in PATH for root
   become: true
@@ -42,7 +42,7 @@
 
 - name: Set download url for borg
   ansible.builtin.set_fact:
-    borg_architecture: >
+    borgmatic_borg_architecture: >
       {% if ansible_facts['architecture'] == 'aarch64' %}
       arm64
       {% else %}
@@ -56,7 +56,9 @@
 - name: Download borgbackup binary from GitHub releases for root
   become: true
   ansible.builtin.get_url:
-    url: "https://github.com/borgbackup/borg/releases/download/{{ borg_version }}/borg-linux-glibc235-{{ borg_architecture | trim | replace('\n', '') }}-gh"
+    url: >-
+      https://github.com/borgbackup/borg/releases/download/{{ borgmatic_borg_version }}/borg-linux-glibc235-{{
+      borgmatic_borg_architecture | trim | replace('\n', '') }}-gh
     dest: "/root/.local/bin/borg"
     mode: "0755"
     owner: "root"
@@ -112,7 +114,7 @@
 - name: Ensure rclone config directory exists for root
   become: true
   ansible.builtin.file:
-    path: "{{ rclone_config_dir }}"
+    path: "{{ borgmatic_rclone_config_dir }}"
     state: directory
     mode: "0700"
     owner: "root"
@@ -122,7 +124,7 @@
   become: true
   ansible.builtin.file:
     state: absent
-    path: "{{ rclone_config_dir }}/rclone.conf"
+    path: "{{ borgmatic_rclone_config_dir }}/rclone.conf"
 
 - name: Ensure mysqldump and pg_dump are installed
   become: true

--- a/ansible/roles/immich/tasks/main.yml
+++ b/ansible/roles/immich/tasks/main.yml
@@ -57,8 +57,10 @@
 
     - name: Initialize borg repository for immich
       become: true
-      ansible.builtin.shell:
-        cmd: "/root/.local/bin/borgmatic --config {{ borgmatic_config_dir | default('/etc/borgmatic.d') }}/immich.yaml repo-create --encryption {{ borgmatic_encryption_mode | default('repokey-blake2') }}"
-      register: borg_repo_create
-      changed_when: "'repository already exists' not in borg_repo_create.stderr"
-      failed_when: borg_repo_create.rc != 0 and 'repository already exists' not in borg_repo_create.stderr
+      ansible.builtin.command:
+        cmd: >-
+          /root/.local/bin/borgmatic --config {{ borgmatic_config_dir | default('/etc/borgmatic.d') }}/immich.yaml
+          repo-create --encryption {{ borgmatic_encryption_mode | default('repokey-blake2') }}
+      register: immich_borg_repo_create
+      changed_when: "'repository already exists' not in immich_borg_repo_create.stderr"
+      failed_when: immich_borg_repo_create.rc != 0 and 'repository already exists' not in immich_borg_repo_create.stderr

--- a/ansible/roles/nextcloud/tasks/main.yml
+++ b/ansible/roles/nextcloud/tasks/main.yml
@@ -32,13 +32,15 @@
 
     - name: Initialize borg repository for nextcloud
       become: true
-      ansible.builtin.shell:
-        cmd: "/root/.local/bin/borgmatic --config {{ borgmatic_config_dir }}/nextcloud.yaml repo-create --encryption {{ nextcloud_backup_borgmatic_encryption_mode | default('repokey-blake2') }}"
-      register: borg_repo_create
-      changed_when: "'repository already exists' not in borg_repo_create.stderr"
+      ansible.builtin.command:
+        cmd: >-
+          /root/.local/bin/borgmatic --config {{ borgmatic_config_dir }}/nextcloud.yaml
+          repo-create --encryption {{ nextcloud_backup_borgmatic_encryption_mode | default('repokey-blake2') }}
+      register: nextcloud_borg_repo_create
+      changed_when: "'repository already exists' not in nextcloud_borg_repo_create.stderr"
       failed_when: >
-        borg_repo_create.rc != 0 and
-        'repository already exists' not in borg_repo_create.stderr
+        nextcloud_borg_repo_create.rc != 0 and
+        'repository already exists' not in nextcloud_borg_repo_create.stderr
 
 - name: Make sure nextcloud service is running
   ansible.builtin.systemd:

--- a/ansible/roles/pangolin/defaults/main.yml
+++ b/ansible/roles/pangolin/defaults/main.yml
@@ -4,7 +4,7 @@ pangolin_dir: /opt/pangolin
 # Deploy Pangolin configuration files (Traefik, config.yml)
 # Set to false when building Packer image (config will be deployed via cloud-init)
 # Set to true when running playbook to update existing server
-deploy_pangolin_config: true
+pangolin_deploy_config: true
 
 # Pangolin configuration variables
 # These should be overridden in host_vars/pangolin/variables.yaml or via secrets
@@ -15,11 +15,11 @@ pangolin_log_level: "info"
 pangolin_secret: ""
 
 # Let's Encrypt email
-le_email: ""
+pangolin_le_email: ""
 
 # SMTP configuration
-smtp_user: ""
-smtp_pass: ""
+pangolin_smtp_user: ""
+pangolin_smtp_pass: ""
 
 # Backup healthcheck URL loaded from Terraform state outputs.
 pangolin_backup_healthcheck_url: ""

--- a/ansible/roles/pangolin/handlers/main.yaml
+++ b/ansible/roles/pangolin/handlers/main.yaml
@@ -4,4 +4,4 @@
   ansible.builtin.systemd:
     name: pangolin
     state: restarted
-  when: deploy_pangolin_config | bool
+  when: pangolin_deploy_config | bool

--- a/ansible/roles/pangolin/tasks/main.yml
+++ b/ansible/roles/pangolin/tasks/main.yml
@@ -22,7 +22,7 @@
     mode: "0644"
     owner: root
     group: root
-  when: deploy_pangolin_config | bool
+  when: pangolin_deploy_config | bool
 
 - name: Create Traefik dynamic configuration
   become: true
@@ -32,7 +32,7 @@
     mode: "0644"
     owner: root
     group: root
-  when: deploy_pangolin_config | bool
+  when: pangolin_deploy_config | bool
 
 - name: Create Traefik configuration
   become: true
@@ -43,7 +43,7 @@
     mode: "0644"
     owner: root
     group: root
-  when: deploy_pangolin_config | bool
+  when: pangolin_deploy_config | bool
 
 - name: Create Pangolin configuration
   become: true
@@ -54,7 +54,7 @@
     mode: "0600"
     owner: root
     group: root
-  when: deploy_pangolin_config | bool
+  when: pangolin_deploy_config | bool
 
 - name: Create compose.yml
   notify: Restart Pangolin service
@@ -80,7 +80,7 @@
     enabled: true
     state: started
     daemon_reload: true
-  when: deploy_pangolin_config | bool
+  when: pangolin_deploy_config | bool
 
 - name: Configure borgmatic backup for Pangolin
   when: pangolin_backup_enabled
@@ -97,10 +97,12 @@
 
     - name: Initialize borg repository for Pangolin
       become: true
-      ansible.builtin.shell:
-        cmd: "/root/.local/bin/borgmatic --config {{ borgmatic_config_dir }}/pangolin.yaml repo-create --encryption {{ borgmatic_encryption_mode | default('repokey-blake2') }}"
-      register: borg_repo_create
-      changed_when: "'repository already exists' not in borg_repo_create.stderr"
+      ansible.builtin.command:
+        cmd: >-
+          /root/.local/bin/borgmatic --config {{ borgmatic_config_dir }}/pangolin.yaml
+          repo-create --encryption {{ borgmatic_encryption_mode | default('repokey-blake2') }}
+      register: pangolin_borg_repo_create
+      changed_when: "'repository already exists' not in pangolin_borg_repo_create.stderr"
       failed_when: >
-        borg_repo_create.rc != 0 and
-        'repository already exists' not in borg_repo_create.stderr
+        pangolin_borg_repo_create.rc != 0 and
+        'repository already exists' not in pangolin_borg_repo_create.stderr

--- a/ansible/roles/pangolin/templates/pangolin_config.yml.j2
+++ b/ansible/roles/pangolin/templates/pangolin_config.yml.j2
@@ -31,9 +31,9 @@ email:
   smtp_host: "mail.infomaniak.com"
   smtp_port: 465
   smtp_secure: true
-  smtp_user: "{{ smtp_user }}"
-  smtp_pass: "{{ smtp_pass }}"
-  no_reply: "{{ smtp_user }}"
+  smtp_user: "{{ pangolin_smtp_user }}"
+  smtp_pass: "{{ pangolin_smtp_pass }}"
+  no_reply: "{{ pangolin_smtp_user }}"
 
 flags:
     require_email_verification: true

--- a/ansible/roles/pangolin/templates/traefik_config.yml.j2
+++ b/ansible/roles/pangolin/templates/traefik_config.yml.j2
@@ -28,7 +28,7 @@ certificatesResolvers:
     acme:
       httpChallenge:
         entryPoint: web
-      email: "{{ le_email }}"
+      email: "{{ pangolin_le_email }}"
       storage: "/letsencrypt/acme.json"
       caServer: "https://acme-v02.api.letsencrypt.org/directory"
 

--- a/ansible/roles/paperless_ngx/tasks/main.yml
+++ b/ansible/roles/paperless_ngx/tasks/main.yml
@@ -46,10 +46,12 @@
 
     - name: Initialize borg repository for Paperless-ngx
       become: true
-      ansible.builtin.shell:
-        cmd: "/root/.local/bin/borgmatic --config {{ borgmatic_config_dir }}/paperless.yaml repo-create --encryption {{ borgmatic_encryption_mode | default('repokey-blake2') }}"
-      register: borg_repo_create
-      changed_when: "'repository already exists' not in borg_repo_create.stderr"
+      ansible.builtin.command:
+        cmd: >-
+          /root/.local/bin/borgmatic --config {{ borgmatic_config_dir }}/paperless.yaml
+          repo-create --encryption {{ borgmatic_encryption_mode | default('repokey-blake2') }}
+      register: paperless_ngx_borg_repo_create
+      changed_when: "'repository already exists' not in paperless_ngx_borg_repo_create.stderr"
       failed_when: >
-        borg_repo_create.rc != 0 and
-        'repository already exists' not in borg_repo_create.stderr
+        paperless_ngx_borg_repo_create.rc != 0 and
+        'repository already exists' not in paperless_ngx_borg_repo_create.stderr

--- a/ansible/roles/rss/tasks/main.yml
+++ b/ansible/roles/rss/tasks/main.yml
@@ -43,10 +43,12 @@
 
     - name: Initialize borg repository for RSS
       become: true
-      ansible.builtin.shell:
-        cmd: "/root/.local/bin/borgmatic --config {{ borgmatic_config_dir }}/rss.yaml repo-create --encryption {{ borgmatic_encryption_mode | default('repokey-blake2') }}"
-      register: borg_repo_create
-      changed_when: "'repository already exists' not in borg_repo_create.stderr"
+      ansible.builtin.command:
+        cmd: >-
+          /root/.local/bin/borgmatic --config {{ borgmatic_config_dir }}/rss.yaml
+          repo-create --encryption {{ borgmatic_encryption_mode | default('repokey-blake2') }}
+      register: rss_borg_repo_create
+      changed_when: "'repository already exists' not in rss_borg_repo_create.stderr"
       failed_when: >
-        borg_repo_create.rc != 0 and
-        'repository already exists' not in borg_repo_create.stderr
+        rss_borg_repo_create.rc != 0 and
+        'repository already exists' not in rss_borg_repo_create.stderr

--- a/ansible/roles/searxng/tasks/main.yml
+++ b/ansible/roles/searxng/tasks/main.yml
@@ -59,10 +59,12 @@
 
     - name: Initialize borg repository for SearXNG
       become: true
-      ansible.builtin.shell:
-        cmd: "/root/.local/bin/borgmatic --config {{ borgmatic_config_dir }}/searxng.yaml repo-create --encryption {{ borgmatic_encryption_mode | default('repokey-blake2') }}"
-      register: borg_repo_create
-      changed_when: "'repository already exists' not in borg_repo_create.stderr"
+      ansible.builtin.command:
+        cmd: >-
+          /root/.local/bin/borgmatic --config {{ borgmatic_config_dir }}/searxng.yaml
+          repo-create --encryption {{ borgmatic_encryption_mode | default('repokey-blake2') }}
+      register: searxng_borg_repo_create
+      changed_when: "'repository already exists' not in searxng_borg_repo_create.stderr"
       failed_when: >
-        borg_repo_create.rc != 0 and
-        'repository already exists' not in borg_repo_create.stderr
+        searxng_borg_repo_create.rc != 0 and
+        'repository already exists' not in searxng_borg_repo_create.stderr

--- a/ansible/roles/security/defaults/main.yml
+++ b/ansible/roles/security/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-ufw_allowed_ports:
+security_ufw_allowed_ports:
   - { port: "22", proto: tcp }
   - { port: "80", proto: tcp }
   - { port: "443", proto: tcp }

--- a/ansible/roles/security/tasks/main.yml
+++ b/ansible/roles/security/tasks/main.yml
@@ -51,7 +51,7 @@
     rule: allow
     port: "{{ item.port }}"
     proto: "{{ item.proto }}"
-  loop: "{{ ufw_allowed_ports }}"
+  loop: "{{ security_ufw_allowed_ports }}"
 
 - name: Enable UFW
   community.general.ufw:

--- a/ansible/roles/semaphore/tasks/main.yml
+++ b/ansible/roles/semaphore/tasks/main.yml
@@ -43,10 +43,12 @@
 
     - name: Initialize borg repository for Semaphore
       become: true
-      ansible.builtin.shell:
-        cmd: "/root/.local/bin/borgmatic --config {{ borgmatic_config_dir }}/semaphore.yaml repo-create --encryption {{ borgmatic_encryption_mode | default('repokey-blake2') }}"
-      register: borg_repo_create
-      changed_when: "'repository already exists' not in borg_repo_create.stderr"
+      ansible.builtin.command:
+        cmd: >-
+          /root/.local/bin/borgmatic --config {{ borgmatic_config_dir }}/semaphore.yaml
+          repo-create --encryption {{ borgmatic_encryption_mode | default('repokey-blake2') }}
+      register: semaphore_borg_repo_create
+      changed_when: "'repository already exists' not in semaphore_borg_repo_create.stderr"
       failed_when: >
-        borg_repo_create.rc != 0 and
-        'repository already exists' not in borg_repo_create.stderr
+        semaphore_borg_repo_create.rc != 0 and
+        'repository already exists' not in semaphore_borg_repo_create.stderr

--- a/ansible/roles/wiki/tasks/main.yml
+++ b/ansible/roles/wiki/tasks/main.yml
@@ -35,13 +35,15 @@
 
     - name: Initialize borg repository for wiki
       become: true
-      ansible.builtin.shell:
-        cmd: "/root/.local/bin/borgmatic --config {{ borgmatic_config_dir }}/wiki.yaml repo-create --encryption {{ borgmatic_encryption_mode | default('repokey-blake2') }}"
-      register: borg_repo_create
-      changed_when: "'repository already exists' not in borg_repo_create.stderr"
+      ansible.builtin.command:
+        cmd: >-
+          /root/.local/bin/borgmatic --config {{ borgmatic_config_dir }}/wiki.yaml
+          repo-create --encryption {{ borgmatic_encryption_mode | default('repokey-blake2') }}
+      register: wiki_borg_repo_create
+      changed_when: "'repository already exists' not in wiki_borg_repo_create.stderr"
       failed_when: >
-        borg_repo_create.rc != 0 and
-        'repository already exists' not in borg_repo_create.stderr
+        wiki_borg_repo_create.rc != 0 and
+        'repository already exists' not in wiki_borg_repo_create.stderr
 
 - name: Make sure wiki service is running
   ansible.builtin.systemd:

--- a/ansible/test.yaml
+++ b/ansible/test.yaml
@@ -21,13 +21,13 @@
         aws_access_key: "{{ state_s3_access_key }}"
         aws_secret_key: "{{ state_s3_secret_key }}"
       register: terraform_state_raw
-      #changed_when: false
+      # changed_when: false
 
     - name: Extract uptime_backup_nextcloud_url from Terraform state outputs
       ansible.builtin.set_fact:
         uptime_backup_nextcloud_url: >-
           {{ (terraform_state_raw.contents | from_json).outputs.uptime_backup_nextcloud_url.value }}
-      #changed_when: false
+      # changed_when: false
 
     - name: Display uptime_backup_nextcloud_url
       ansible.builtin.debug:

--- a/packer/pangolin/ansible/site.yml
+++ b/packer/pangolin/ansible/site.yml
@@ -4,7 +4,7 @@
   become: true
 
   vars:
-    ufw_allowed_ports:
+    security_ufw_allowed_ports:
       - { port: "22", proto: tcp }
       - { port: "80", proto: tcp }
       - { port: "443", proto: tcp }
@@ -14,7 +14,7 @@
       - "{{ ansible_facts['user_id'] }}"
     # Disable Pangolin config deployment in Packer build
     # Configuration will be deployed via cloud-init or later via Ansible playbook
-    deploy_pangolin_config: false
+    pangolin_deploy_config: false
 
   roles:
     - role: geerlingguy.docker


### PR DESCRIPTION
## Summary

- `ansible-lint` now passes clean (0 failures). Fixed the schema[playbook] error that was silently aborting lint of `docker.yml`/`pangolin.yaml`/`pi.yml` entirely (`roles:` items used `name:` instead of the schema-required `role:` — Ansible resolves both the same way at runtime, so this is purely a schema-compliance fix), plus the play-naming, indentation, command-vs-shell, var-naming, line-length and comment-spacing findings across the repo.
- `tofu fmt -check -recursive` and `tofu validate` (pangolin + proxmox, and `pangolin_config` manually) were already clean — no OpenTofu changes needed.

## Notable calls

- **paperless_ngx's 13 `var-naming[no-role-prefix]` findings are intentionally left as warnings**, documented in `ansible/.ansible-lint-ignore`. Those vars (`paperless_admin_user`, `paperless_db_password`, etc.) are deliberately unprefixed so they match `ansible/secrets.sops.yaml` keys 1:1 for the `community.sops.load_vars` override mechanism. Renaming them to `paperless_ngx_*` would require re-encrypting `secrets.sops.yaml` with the age key, which isn't available in this environment — didn't want to risk breaking secret injection blind.
- **`secrets.sops.yaml` is now excluded from ansible-lint** — its ciphertext lines can't be rewrapped by hand without invalidating SOPS's MAC.
- Renamed pangolin's `smtp_user`/`smtp_pass`/`le_email`/`deploy_pangolin_config` to `pangolin_*`, which let me delete the now-redundant `host_vars/pangolin/variables.yaml` bridge lines (the secrets already load under the `pangolin_*` names directly). Also updated the matching var in `packer/pangolin/ansible/site.yml`.

## Test plan

- [x] `mise run ansible-lint` — 0 failures, only the documented paperless_ngx warnings remain
- [x] `ansible-playbook --syntax-check` on every changed playbook (docker.yml, pangolin.yaml, pi.yml, 00-setup.yaml, test.yaml)
- [x] `mise run lint` (OpenTofu fmt-check + validate, both targets) — passes
- [x] `tofu validate` on `tofu/pangolin_config` (not wired into mise) — passes
- [x] Grepped the whole repo for every renamed variable to confirm no stale references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)