### PR TITLE
fix(dawarich): create redis data dir with correct uid/gid at deploy

### DIFF
--- a/ansible/roles/dawarich/tasks/main.yml
+++ b/ansible/roles/dawarich/tasks/main.yml
@@ -4,7 +4,6 @@
   loop:
     - "{{ dawarich_base_path }}"
     - "{{ dawarich_base_path }}/postgresql"
-    - "{{ dawarich_base_path }}/redis"
     - "{{ dawarich_base_path }}/public"
     - "{{ dawarich_base_path }}/watched"
     - "{{ dawarich_base_path }}/storage"
@@ -14,6 +13,15 @@
     state: directory
     owner: "{{ ansible_facts['user_id'] }}"
     group: "{{ ansible_facts['user_gid'] }}"
+
+- name: Ensure Dawarich redis folder exists with redis image uid/gid
+  become: true
+  ansible.builtin.file:
+    mode: "0755"
+    path: "{{ dawarich_base_path }}/redis"
+    state: directory
+    owner: "999"
+    group: "999"
 
 - name: Template compose configuration
   notify: Restart dawarich


### PR DESCRIPTION
Post-deploy, the redis data volume always needed a manual `sudo chown -R 999:999 redis` on the docker host before dawarich-redis would start cleanly, because the role created `./redis` owned by the ansible user like the other app data dirs.

Unlike `dawarich-app`/`dawarich-sidekiq` (which get `PUID`/`PGID` injected from `ansible_facts`), `dawarich-redis` runs the stock `redis:7.4-alpine` image unmodified, so it always writes as its native uid/gid `999:999`.

Split the redis directory out of the shared folder-creation loop and create it directly with `owner: "999"` / `group: "999"`, so a fresh deploy no longer needs the manual chown step.